### PR TITLE
Delete events and user_id on keys for the trigger

### DIFF
--- a/credential.proto
+++ b/credential.proto
@@ -4,17 +4,20 @@ package credential.proto;
 
 message CredentialEventKey {
   string id = 1;
+  // the user who triggered the event
+  string user_id = 2;
 }
 
 message OAuth2Client {
   string user_id = 1;
   string client_name = 2;
-  string organization =3;
+  string organization = 3;
 
 }
 
 message CredentialEvents{
   oneof event {
     OAuth2Client oauth2_client_created = 2;
+    OAuth2Client oauth2_client_deleted = 3;
   }
 }

--- a/customer.proto
+++ b/customer.proto
@@ -4,6 +4,8 @@ package customer.proto;
 
 message CustomerEventKey {
   string id = 1;
+  // the user who triggered the event
+  string user_id = 2;
 }
 
 message Customer {
@@ -13,5 +15,6 @@ message Customer {
 message CustomerEvents{
   oneof event {
     Customer created = 2;
+    Customer blocked = 3;
   }
 }

--- a/nfts.proto
+++ b/nfts.proto
@@ -5,6 +5,7 @@ package nfts.proto;
 
 message NftEventKey {
   string id = 1;
+  // the user that triggered the event
   string user_id = 2;
 }
 

--- a/organization.proto
+++ b/organization.proto
@@ -4,6 +4,7 @@ package organization.proto;
 
 message OrganizationEventKey {
   string id = 1;
+  // the user who triggered the event
   string user_id = 2;
 }
 
@@ -33,5 +34,7 @@ message OrganizationEvents {
     Project project_deactivated = 3;
     Organization organization_created = 4;
     Member member_added = 5;
+    Member member_deactivated = 6;
+    Member member_reactivated = 7;
   }
 }

--- a/treasury.proto
+++ b/treasury.proto
@@ -3,6 +3,8 @@ package treasury.proto;
 
 message TreasuryEventKey {
   string id = 1;
+  // the user who triggered the event
+  string user_id = 2;
 }
 
 message TreasuryEvents {

--- a/webhook.proto
+++ b/webhook.proto
@@ -4,6 +4,8 @@ package webhook.proto;
 
 message WebhookEventKey {
   string id = 1;
+  // the user who triggered the event
+  string user_id = 2;
 }
 
 message Webhook {
@@ -14,5 +16,6 @@ message Webhook {
 message WebhookEvents {
   oneof event {
     Webhook created = 2;
+    Webhook deleted = 3;
   }
 }


### PR DESCRIPTION
## Changes
- Add delete events for webhooks, credentials
- Deactivate and reactive customers
- Set user_id on the keys to track who triggered the event. Not used currently but will be used for auditing keeping in the future.