### PR TITLE
Passthrough Fields for NFT and collection addresses

### DIFF
--- a/credits.proto
+++ b/credits.proto
@@ -16,7 +16,6 @@ enum Action {
   RETRY_MINT = 4;
   CREATE_WALLET = 5;
   RETRY_DROP = 6;
-
 }
 
 enum Blockchain {

--- a/nfts.proto
+++ b/nfts.proto
@@ -98,18 +98,15 @@ message CreateEditionTransaction {
   int64 amount = 6;
   int32 fee_numerator = 7;
   string fee_receiver = 8;
-  string collection_id = 9;
 }
 
 message MintEditionTransaction {
   string receiver = 2;
   int64 amount = 3;
-  string collection_id = 4;
 }
 
 message UpdateEdtionTransaction {
   EditionInfo edition_info = 1;
-  string collection_id = 2;
 }
 
 message SolanaEvents {

--- a/polygon_nfts.proto
+++ b/polygon_nfts.proto
@@ -10,6 +10,8 @@ message PolygonNftEventKey {
 
 message PolygonTransaction {
   bytes data = 1;
+  string contract_address = 2;
+  int32 edition_id = 3;
 }
 
 message PermitArgsHash {

--- a/treasury.proto
+++ b/treasury.proto
@@ -109,6 +109,8 @@ message TreasuryEvents {
   message PolygonTransactionResult {
     optional string hash = 1;
     TransactionStatus status = 2;
+    string contract_address = 3;
+    int32 edition_id = 4;
   }
 
   oneof event {


### PR DESCRIPTION
### Changes
- Pass through the contract_address and edition_id from the hub-nfts-polygon through hub-treasuries to hub-nfts so it can write the address fields for collections and mints
- Remove collection_id from payload as its the id now.