### PR TITLE
Nft Events for Drop Created and Minted

### DIFF
--- a/nfts.proto
+++ b/nfts.proto
@@ -114,6 +114,12 @@ message UpdateEdtionTransaction {
   string collection_id = 2;
 }
 
+enum CreationStatus {
+  IN_PROGRESS = 0;
+  COMPLETED = 1;
+  FAILED = 2;
+}
+
 message SolanaEvents {
   oneof event {
     MetaplexMasterEditionTransaction create_drop = 1;
@@ -132,7 +138,6 @@ message TransferPolygonAsset {
   int64 amount = 4;
   
 }
-
 
 message PolygonEvents {
   oneof event {
@@ -153,5 +158,7 @@ message NftEvents {
     TransferMintTransaction transfer_mint = 7;
     MintTransaction retry_mint = 8;
     DropTransaction retry_drop = 9;
+    CreationStatus drop_created = 10;
+    CreationStatus drop_minted = 11;
   }
 }


### PR DESCRIPTION
## Changes
- Nfts service emits drop_created and drop_minted with creation status of in_progress while created and re-emits with completed when landed on the blockchain and failed if not.