### PR TITLE
Add drop_id to drop_minted event of nfts

### DIFF
--- a/nfts.proto
+++ b/nfts.proto
@@ -120,6 +120,15 @@ enum CreationStatus {
   FAILED = 2;
 }
 
+message DropCreation {
+  CreationStatus status = 2;
+}
+
+message MintCreation {
+  string drop_id = 1;
+  CreationStatus status = 2;
+}
+
 message SolanaEvents {
   oneof event {
     MetaplexMasterEditionTransaction create_drop = 1;
@@ -135,8 +144,7 @@ message TransferPolygonAsset {
   string collection_mint_id = 1;
   string owner_address = 2;
   string recipient_address = 3;
-  int64 amount = 4;
-  
+  int64 amount = 4;  
 }
 
 message PolygonEvents {
@@ -158,7 +166,7 @@ message NftEvents {
     TransferMintTransaction transfer_mint = 7;
     MintTransaction retry_mint = 8;
     DropTransaction retry_drop = 9;
-    CreationStatus drop_created = 10;
-    CreationStatus drop_minted = 11;
+    DropCreation drop_created = 10;
+    MintCreation drop_minted = 11;
   }
 }


### PR DESCRIPTION
## Changes
- In order to write mint permissions need the drop_id on the event